### PR TITLE
Example project mapping added (maven)

### DIFF
--- a/Maven2/example/1.0/example-1.0.buildspec
+++ b/Maven2/example/1.0/example-1.0.buildspec
@@ -1,0 +1,6 @@
+groupId=example
+artifactId=example
+version=1.0
+
+repoType=git
+repoUrl=https://github.com/karolh2000/pyrsia-projects-for-testing

--- a/Maven2/example/1.0/example-1.0.mapping
+++ b/Maven2/example/1.0/example-1.0.mapping
@@ -1,0 +1,10 @@
+{
+  "package_type": "Maven2",
+  "package_specific_id": "example:example:1.0",
+  "source_repository": {
+    "Git": {
+      "url": https://github.com/karolh2000/pyrsia-projects-for-testing"
+    }
+  },
+  "build_spec_url": "https://raw.githubusercontent.com/pyrsia/pyrsia-mappings/main/Maven2/example/1.0/example-1.0.buildspec"
+}


### PR DESCRIPTION
The idea behind this PR is to have at least one maven project/sources mapped that is not available in the maven central repo. Basically, if the jar is not found in the Pyrsia network then the dependent project fails (maven project that uses the mapped jar). I'm planning to use the mapped jar/sources in the integration tests (pyrsia build and maven dependencies). 